### PR TITLE
Update brew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Mailpit runs as a single binary and can be installed in different ways:
 
 ### Install via Brew (Mac)
 
-Add the repository to your taps with `brew tap axllent/apps`, and then install Mailpit with `brew install mailpit`.
+Add the repository to your taps with `brew tap axllent/apps`, and then install Mailpit with `brew install axllent/apps/mailpit`.
 
 
 ### Install via bash script (Linux & Mac)


### PR DESCRIPTION
When using Brew, it will install the core formula for Mailpit instead of the formula in the tap if there is a conflict with formula names. To ensure the installation of the correct formula, specify the full formula path.